### PR TITLE
variable-number-of-arguments.go: Sum the numbers, not the indexes.

### DIFF
--- a/code/variable-number-of-arguments.go
+++ b/code/variable-number-of-arguments.go
@@ -1,6 +1,6 @@
 func sumOf(numbers ...int) int {
     var sum = 0
-    for number := range(numbers) {
+    for _, number := range(numbers) {
         sum += number
     }
     return sum


### PR DESCRIPTION
In an expression like

```go
slice := []int{42, 597, 12}
for i, v := range slice {
  // …
}
```

`i` is the *index* and `v` is the actual *value*. Since you're not using the index in the example, this patch assigns it to the blank identifier `_`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jiyinyiyong/swift-is-like-go/4)
<!-- Reviewable:end -->
